### PR TITLE
Added top level await support to Eval

### DIFF
--- a/ChromeAutomation/Chrome.cs
+++ b/ChromeAutomation/Chrome.cs
@@ -66,10 +66,17 @@ namespace ChromeAutomation
 
         public string Eval(string cmd)
         {
-            var json = @"{""method"":""Runtime.evaluate"",""params"":{""expression"":"""+cmd+@""",""objectGroup"":""console"",""includeCommandLineAPI"":true,""doNotPauseOnExceptions"":false,""returnByValue"":false},""id"":1}";
+            return Eval(cmd, false);
+        }
+	    public string Eval(string cmd, bool allowTopLevelAwait)
+        {
+            string awaitParam = "";
+            if (allowTopLevelAwait)  {
+                awaitParam = @"""replMode"":true,";
+            }
+            var json = @"{""method"":""Runtime.evaluate"",""params"":{""expression"":"""+cmd + @"""," + awaitParam + @"objectGroup"":""console"",""includeCommandLineAPI"":true,""doNotPauseOnExceptions"":false,""returnByValue"":false},""id"":1}";
             return this.SendCommand(json);
         }
-
         public string SendCommand(string cmd)
         {
             WebSocket4Net.WebSocket j = new WebSocket4Net.WebSocket(this.sessionWSEndpoint);


### PR DESCRIPTION
Runtime.evaluate needs replMode:true param to support evaluate "await doSomething()"   (also allow let redeclaration but await is the big use case)
https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate